### PR TITLE
Feature/event notification

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,4 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 25
+  Enabled: false

--- a/app/jobs/event_notification_job.rb
+++ b/app/jobs/event_notification_job.rb
@@ -1,0 +1,10 @@
+class EventNotificationJob < ApplicationJob
+  def self.perform(event)
+    event.presentations.joins(:person).each do |presentation|
+      PersonMailer.presentation_notification(
+        presentation.person,
+        presentation.event.date
+      ).deliver
+    end
+  end
+end

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -1,0 +1,14 @@
+class PersonMailer < ApplicationMailer
+  include ActionView::Helpers::DateHelper
+  def presentation_notification(presenter, event_date)
+    @presenter = presenter
+    @event_date = event_date.strftime('%a %b %d')
+    @notification_period = distance_of_time_in_words(
+      Event::NOTIFICATION_PERIOD
+    )
+    mail(
+      to: presenter.email,
+      subject: "You have a presentation in #{@notification_period}"
+    )
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 # app/models/event.rb
 class Event < ApplicationRecord
+  NOTIFICATION_PERIOD = 1.day
   has_many :presentations
 
   validates :date,
@@ -10,4 +11,7 @@ class Event < ApplicationRecord
             presence: true
 
   scope :upcoming, -> { where('date >= ?', Time.zone.today) }
+  scope :requiring_notification, -> do
+    where('date = ?', Date.current - NOTIFICATION_PERIOD)
+  end
 end

--- a/app/views/person_mailer/presentation_notification.html.erb
+++ b/app/views/person_mailer/presentation_notification.html.erb
@@ -1,0 +1,12 @@
+<DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Greetings <%= @presenter.first_name if @presenter.first_name %></h1>
+    <p>This is a reminder for your upcoming presentation on
+      <%= @event_date %>
+    </p>
+  </body>
+</html>

--- a/lib/tasks/send_presentation_notifications.rake
+++ b/lib/tasks/send_presentation_notifications.rake
@@ -1,0 +1,8 @@
+require 'rake'
+
+desc 'Sends email notifications to all presenters of upcoming events'
+task send_presentation_notifications: :environment do
+  Event.requiring_notification.each do |event|
+    EventNotificationJob.perform_later(event)
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,11 +3,25 @@ FactoryGirl.define do
   factory :person do
     first_name 'John'
     last_name 'Doe'
-    email "john.doe#{Random.rand(1000)}@example.com"
+    email { "john.doe#{Random.rand(1000)}@example.com" }
     password 'abc123'
     password_confirmation 'abc123'
     date_of_birth Date.new(1970, 1, 1)
     gender 'Computer'
+  end
+
+  factory :event do
+    name 'Show & Tell'
+    location 'Board Room'
+    date Date.new(2017, 2, 24)
+
+    trait :requiring_notification do
+      date Time.zone.today - Event::NOTIFICATION_PERIOD
+    end
+
+    trait :not_requiring_notification do
+      date Time.zone.today + Event::NOTIFICATION_PERIOD
+    end
   end
 
   factory :presentation do
@@ -16,11 +30,9 @@ FactoryGirl.define do
     duration 900
     person
     event
-  end
 
-  factory :event do
-    name 'Show & Tell'
-    location 'Board Room'
-    date Date.new(2017, 2, 24)
+    trait :requiring_notification do
+      event { FactoryGirl.build(:event, :requiring_notification) }
+    end
   end
 end

--- a/spec/jobs/event_notification_job_spec.rb
+++ b/spec/jobs/event_notification_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe EventNotificationJob do
+  subject(:performed_job) { described_class.perform(event) }
+  let(:event) { FactoryGirl.create(:event, :requiring_notification) }
+  before { FactoryGirl.create(:presentation, event: event) }
+
+  describe '.perform' do
+    context 'when there are multiple presentations for an event' do
+      before { FactoryGirl.create(:presentation, event: event) }
+      it 'sends an email to the presenter of those presentations' do
+        expect { performed_job }
+          .to change { ActionMailer::Base.deliveries.count }
+          .by(event.presentations.length)
+      end
+    end
+    context 'when there are no presentations for an event' do
+      before { event.presentations = [] }
+      it 'sends zero emails' do
+        expect { performed_job }
+          .not_to change { ActionMailer::Base.deliveries.count }
+      end
+    end
+  end
+end

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe PersonMailer do
+  describe '.presentation_notification' do
+    let(:person) { FactoryGirl.create(:person) }
+    subject do
+      described_class.presentation_notification(person, Date.current).deliver
+    end
+
+    it 'greets the presenter' do
+      expect(subject.body).to include("Greetings")
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -57,4 +57,29 @@ RSpec.describe Event, type: :model do
       it { is_expected.to_not include(event_past) }
     end
   end
+
+  describe '.requiring_notification' do
+    subject(:events_requiring_notification) do
+      described_class.requiring_notification
+    end
+    context 'when there are events aligning with the NOTIFICATION_PERIOD' do
+      let(:required_notif) do
+        FactoryGirl.create(:event, :requiring_notification)
+      end
+      let(:unrequired_notif) do
+        FactoryGirl.create(:event, :not_requiring_notification)
+      end
+      it 'returns an array of Events requiring notification' do
+        expect(events_requiring_notification).to include(required_notif)
+      end
+      it 'doesnt include Events that arent requiring notification' do
+        expect(events_requiring_notification).not_to include(unrequired_notif)
+      end
+    end
+    context 'when there are no events aligning with the NOTIFICATION_PERIOD' do
+      it 'returns an empty array' do
+        expect(events_requiring_notification).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
 - Users should be able to configure how many days before a presentation the presenter is notified of their talk.
 - The configuration should apply to all upcoming presentations