### PR TITLE
Fix /upcoming-events route.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   resources :people
-  resources :events, only: [:show, :create, :new, :upcoming] do
-    get "/upcoming-events", to: 'events#upcoming', on: :collection
+  resources :events, only: [:show, :create, :new] do
+    get 'upcoming', to: 'events#upcoming', on: :collection
   end
   resources :presentations, only: [:show, :create, :new]
 


### PR DESCRIPTION
Reference: https://www.pivotaltracker.com/story/show/140277481/comments/164547387

The upcoming-events route had an error where visiting /events/upcoming-events
was sending you to the events#upcoming action instead of the intended
/upcoming-events route corresponding to that action. This change fixes that issue