### PR TITLE
Add presentation validation

### DIFF
--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -3,12 +3,14 @@ class Presentation < ApplicationRecord
   belongs_to :event
 
   validates :topic,     presence: true
-  validates :duration,  presence: true, numericality: true
   validates :person,    presence: true, unless: :presenter
   validates :presenter, presence: true, unless: :person
   validates :event,     presence: true
+  validates :duration,  presence: true, numericality: {
+    greater_than: 0, less_than_or_equal_to: 15
+  }
 
-  validate  :person_or_presenter
+  validate :person_or_presenter
 
   def presenter_name
     person ? person.first_name : presenter

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -13,7 +13,7 @@ FactoryGirl.define do
   factory :presentation do
     topic 'Being Awesome'
     description 'How to be awesome and stuff'
-    duration 900
+    duration 15
     person
     event
   end

--- a/spec/models/presentation_spec.rb
+++ b/spec/models/presentation_spec.rb
@@ -10,10 +10,14 @@ RSpec.describe Presentation, type: :model do
 
     it { is_expected.to validate_presence_of :topic }
     it { is_expected.to validate_presence_of :duration }
-    it { is_expected.to validate_numericality_of :duration }
 
     it { is_expected.to belong_to :person }
     it { is_expected.to belong_to :event }
+
+    it 'is expected to validate duration is between 0 and 15' do
+      expect(subject).to validate_numericality_of(:duration)
+        .is_greater_than(0).is_less_than_or_equal_to(15)
+    end
 
     it { is_expected.to be_valid }
 


### PR DESCRIPTION
Presentations should not be more than 15min in an effort to keep talks concise.

I've made some changes to the FactoryGirl presentation Factory so that the presentation
objects it's pumping out pass validation. I also fixed a spacing error.