### PR TITLE
Refactor spec to work as intended

### DIFF
--- a/spec/jobs/event_notification_job_spec.rb
+++ b/spec/jobs/event_notification_job_spec.rb
@@ -2,20 +2,30 @@ require 'rails_helper'
 
 describe EventNotificationJob do
   subject(:performed_job) { described_class.perform(event) }
-  let(:event) { FactoryGirl.create(:event, :requiring_notification) }
-  before { FactoryGirl.create(:presentation, event: event) }
 
   describe '.perform' do
     context 'when there are multiple presentations for an event' do
-      before { FactoryGirl.create(:presentation, event: event) }
+      let(:event) do
+        FactoryGirl.create(
+          :event,
+          :requiring_notification,
+          presentations: build_list(:presentation, 2)
+        )
+      end
       it 'sends an email to the presenter of those presentations' do
         expect { performed_job }
           .to change { ActionMailer::Base.deliveries.count }
-          .by(event.presentations.length)
+          .by(2)
       end
     end
     context 'when there are no presentations for an event' do
-      before { event.presentations = [] }
+      let(:event) do
+        FactoryGirl.create(
+          :event,
+          :requiring_notification,
+          presentations: []
+        )
+      end
       it 'sends zero emails' do
         expect { performed_job }
           .not_to change { ActionMailer::Base.deliveries.count }

--- a/spec/models/presentation_spec.rb
+++ b/spec/models/presentation_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Presentation, type: :model do
   let(:event)  { FactoryGirl.create(:event) }
 
   describe 'validate model' do
-    subject { FactoryGirl.create(:presentation) }
-
     it { is_expected.to validate_presence_of :topic }
     it { is_expected.to validate_presence_of :duration }
 
@@ -18,8 +16,6 @@ RSpec.describe Presentation, type: :model do
       expect(subject).to validate_numericality_of(:duration)
         .is_greater_than(0).is_less_than_or_equal_to(15)
     end
-
-    it { is_expected.to be_valid }
 
     describe 'person and presenter validation' do
       subject { described_class.new(presentation) }


### PR DESCRIPTION
This spec was passing but not quite doing what we intended it to. I've made some
refactors to bring it back to where it should be.

Replaced some .length calls with static integers just so we can be a little bit
more clear with what exactly is going on here.