### PR TITLE
Feature/user roles

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,5 +1,7 @@
 class Person < ApplicationRecord
   has_many :presentations
+  has_many :person_roles
+  has_many :roles, through: :person_roles
 
   before_save do
     email.downcase!
@@ -22,4 +24,8 @@ class Person < ApplicationRecord
             uniqueness: { case_sensitive: false }
 
   has_secure_password
+
+  def admin?
+    roles.detect(&:admin?).present?
+  end
 end

--- a/app/models/person_role.rb
+++ b/app/models/person_role.rb
@@ -1,0 +1,4 @@
+class PersonRole < ApplicationRecord
+  belongs_to :person
+  belongs_to :role
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,6 @@
+class Role < ApplicationRecord
+  has_many :person_roles
+  has_many :people, through: :person_roles
+
+  enum name: { admin: 0 }
+end

--- a/db/migrate/20170306230433_create_roles.rb
+++ b/db/migrate/20170306230433_create_roles.rb
@@ -1,0 +1,9 @@
+class CreateRoles < ActiveRecord::Migration[5.0]
+  def change
+    create_table :roles do |t|
+      t.column :name, :integer
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170306230913_create_person_roles.rb
+++ b/db/migrate/20170306230913_create_person_roles.rb
@@ -1,0 +1,10 @@
+class CreatePersonRoles < ActiveRecord::Migration[5.0]
+  def change
+    create_table :person_roles do |t|
+      t.references :person, index: true
+      t.references :role, index: true
+    end
+    add_foreign_key :person_roles, :people
+    add_foreign_key :person_roles, :roles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170223213553) do
+ActiveRecord::Schema.define(version: 20170306230433) do
 
   create_table "events", force: :cascade do |t|
     t.date     "date",       null: false
@@ -26,8 +26,8 @@ ActiveRecord::Schema.define(version: 20170223213553) do
     t.string   "email"
     t.date     "date_of_birth"
     t.string   "gender"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
     t.string   "password_digest"
     t.string   "oauth_token"
     t.datetime "oauth_expires_at"
@@ -54,6 +54,12 @@ ActiveRecord::Schema.define(version: 20170223213553) do
     t.integer  "event_id"
     t.index ["event_id"], name: "index_presentations_on_event_id"
     t.index ["person_id"], name: "index_presentations_on_person_id"
+  end
+
+  create_table "roles", force: :cascade do |t|
+    t.integer  "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "staff", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170306230433) do
+ActiveRecord::Schema.define(version: 20170306230913) do
 
   create_table "events", force: :cascade do |t|
     t.date     "date",       null: false
@@ -41,6 +41,13 @@ ActiveRecord::Schema.define(version: 20170306230433) do
     t.integer "presentation_id"
     t.index ["person_id"], name: "index_person_presentations_on_person_id"
     t.index ["presentation_id"], name: "index_person_presentations_on_presentation_id"
+  end
+
+  create_table "person_roles", force: :cascade do |t|
+    t.integer "person_id"
+    t.integer "role_id"
+    t.index ["person_id"], name: "index_person_roles_on_person_id"
+    t.index ["role_id"], name: "index_person_roles_on_role_id"
   end
 
   create_table "presentations", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -8,6 +8,10 @@ FactoryGirl.define do
     password_confirmation 'abc123'
     date_of_birth Date.new(1970, 1, 1)
     gender 'Computer'
+
+    trait :admin do
+      roles { build_list(:role, 1, :admin) }
+    end
   end
 
   factory :event do
@@ -33,6 +37,12 @@ FactoryGirl.define do
 
     trait :requiring_notification do
       event { FactoryGirl.build(:event, :requiring_notification) }
+    end
+  end
+
+  factory :role do
+    trait :admin do
+      name :admin
     end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Person, type: :model do
     it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
     it { is_expected.to have_secure_password }
     it { is_expected.to be_valid }
+    it { is_expected.to have_many(:roles) }
 
     it "expects first_name to be longer than 1 character" do
       subject.first_name = "A"
@@ -24,6 +25,22 @@ RSpec.describe Person, type: :model do
     it "expects gender to be stored lower-case" do
       subject.save
       expect(subject.gender).to eq(subject.gender.downcase)
+    end
+  end
+
+  describe 'admin?' do
+    subject { person.admin? }
+    context 'the person has an admin role assigned' do
+      let(:person) { FactoryGirl.create(:person, :admin) }
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+    context 'the person doesnt have an admin role assigned' do
+      let(:person) { FactoryGirl.create(:person) }
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
     end
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Role, type: :model do
+  describe 'validate model' do
+    it { is_expected.to have_many(:people) }
+  end
+end


### PR DESCRIPTION
In this PR we are adding the ability to distinguish between person roles to delegate privileges.
The architecture that I've taken is something like this:

A person can have multiple roles. Admin is implemented in this PR but there could be a 'blogger' roll etc. introduced in the future.

Using the pundit gem we mark which controller actions a person can visit. By default we are making all data altering actions available to admins only.