### PR TITLE
Feature/sign in mandatory

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,9 +2,16 @@ class ApplicationController < ActionController::Base
   include Pundit
   protect_from_forgery with: :exception
   helper_method :current_person
+  helper_method :authenticate_person
+
+  private
 
   def current_person
     @current_person ||= Person.find(session[:person_id]) if session[:person_id]
+  end
+
+  def authenticate_person
+    redirect_to sign_in_path unless current_person
   end
 
   alias_method :current_user, :current_person

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,6 @@
-# app/controllers/events_controller.rb
 class EventsController < ApplicationController
+  before_action :authenticate_person
+
   def show
     @event = Event.find(params[:id])
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,4 +1,6 @@
 class PeopleController < ApplicationController
+  before_action :authenticate_person
+
   def index
     @people = Person.all
   end

--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -1,4 +1,6 @@
 class PresentationsController < ApplicationController
+  before_action :authenticate_person
+
   def show
     @presentation = Presentation.find(params[:id])
   end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,3 +1,7 @@
 class WelcomeController < ApplicationController
-  def index; end
+  def index
+    @next_event = Event.upcoming.order(:date).first
+  end
+
+  def sign_in; end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,6 @@
 class WelcomeController < ApplicationController
+  before_action :authenticate_person, except: [:sign_in]
+
   def index
     @next_event = Event.upcoming.order(:date).first
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,12 @@
+<header>
+  <%= link_to image_tag('stembolt_logo', class: 'header-logo'), root_path %>
+  <% if current_person %>
+    <div class='header-links'>
+      <ul>
+        <li><%= link_to 'Upcoming Events', upcoming_events_path %></li>
+        <li><%= link_to 'New Presentation', new_presentation_path %></li>
+        <li><%= link_to 'Sign Out', signout_path %></li>
+      </ul>
+    </div>
+  <% end %>
+</header>

--- a/app/views/welcome/sign_in.html.erb
+++ b/app/views/welcome/sign_in.html.erb
@@ -1,0 +1,1 @@
+<%= link_to 'Sign in with Google', '/auth/google_oauth2' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   get 'signout', to: 'sessions#destroy', as: 'signout'
   get 'authentication/google', to: 'authentication#google'
 
+  get 'sign_in', to: 'welcome#sign_in', as: 'sign_in'
+
   resources :sessions, only: [:destroy]
   resources :people
   resources :events, only: [:show, :create, :new] do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ApplicationController, type: :controller do
     subject { get :index }
 
     context 'when the person is signed in' do
-      before { mock_pundit_user_as(person) }
+      before { sign_in_as(person) }
       let(:person) { FactoryGirl.build(:person) }
 
       it { is_expected.to_not redirect_to(sign_in_path) }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,22 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationController, type: :controller do
+  controller(described_class) do
+    before_action :authenticate_person
+    def index
+      current_user
+
+      render nothing: true
+    end
+  end
+
   describe '.current_person' do
-    subject { controller.current_person }
+    subject { get :index }
 
     context 'when a session is active' do
-      before { session[:person_id] = person.id }
       let(:person) { FactoryGirl.create(:person) }
+      before { session[:person_id] = person.id }
 
-      it 'returns the corresponding person object' do
-        expect(subject).to eq(person)
+      it 'memoizes the current person' do
+        subject
+        expect(assigns[:current_person]).to eq(person)
       end
     end
 
     context 'when there is no active session' do
       before { session[:person_id] = nil }
 
-      it { is_expected.to be_nil }
+      it 'the current person in nil' do
+        expect(assigns[:current_person]).to be_nil
+      end
+    end
+  end
+
+  describe '.authenticate_person' do
+    subject { get :index }
+
+    context 'when the person is signed in' do
+      before { mock_pundit_user_as(person) }
+      let(:person) { FactoryGirl.build(:person) }
+
+      it { is_expected.to_not redirect_to(sign_in_path) }
+    end
+
+    context 'when the person isnt signed in' do
+      before { session[:person_id] = nil }
+
+      it { is_expected.to redirect_to(sign_in_path) }
     end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EventsController, type: :controller do
   context 'the current person is an admin' do
     let(:admin_person) { FactoryGirl.build(:person, :admin) }
 
-    before { mock_pundit_user_as(admin_person) }
+    before { sign_in_as(admin_person) }
 
     describe 'POST #create' do
       subject { post :create, params: { event: params } }
@@ -49,7 +49,7 @@ RSpec.describe EventsController, type: :controller do
   context 'the current person is a non-admin' do
     let(:non_admin) { FactoryGirl.build(:person) }
 
-    before { mock_pundit_user_as(non_admin) }
+    before { sign_in_as(non_admin) }
 
     describe 'POST #create' do
       subject { post :create, params: { event: params } }

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -2,6 +2,9 @@
 require 'rails_helper'
 
 RSpec.describe PeopleController, type: :controller do
+  before { sign_in_as(person) }
+  let(:person) { FactoryGirl.build(:person) }
+
   describe "GET #index" do
     subject { get :index }
 

--- a/spec/controllers/presentations_controller_spec.rb
+++ b/spec/controllers/presentations_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PresentationsController, type: :controller do
   context 'the current person is an admin' do
     let(:admin_person) { FactoryGirl.build(:person, :admin) }
 
-    before { mock_pundit_user_as(admin_person) }
+    before { sign_in_as(admin_person) }
 
     describe 'GET #new' do
       subject { get :new }
@@ -53,7 +53,7 @@ RSpec.describe PresentationsController, type: :controller do
   context 'the current person is a non-admin' do
     let(:non_admin) { FactoryGirl.build(:person) }
 
-    before { mock_pundit_user_as(non_admin) }
+    before { sign_in_as(non_admin) }
 
     describe 'GET #new' do
       subject { get :new }

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -7,4 +7,11 @@ RSpec.describe WelcomeController, type: :controller do
     it { is_expected.to be_successful }
     it { is_expected.to render_template(:index) }
   end
+
+  describe 'GET #sign_in' do
+    subject { get :sign_in }
+
+    it { is_expected.to be_successful }
+    it { is_expected.to render_template(:sign_in) }
+  end
 end

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe WelcomeController, type: :controller do
+  before { sign_in_as(person) }
+  let(:person) { FactoryGirl.build(:person) }
+
   describe 'GET #index' do
     subject { get :index }
 

--- a/spec/support/pundit.rb
+++ b/spec/support/pundit.rb
@@ -1,4 +1,6 @@
 def mock_pundit_user_as(person)
-  allow_any_instance_of(ApplicationController).to receive(:current_user)
+	allow_any_instance_of(ApplicationController).to receive(:current_user)
+    .and_return(person)
+  allow_any_instance_of(ApplicationController).to receive(:current_person)
     .and_return(person)
 end

--- a/spec/support/sign_in.rb
+++ b/spec/support/sign_in.rb
@@ -1,5 +1,5 @@
-def mock_pundit_user_as(person)
-	allow_any_instance_of(ApplicationController).to receive(:current_user)
+def sign_in_as(person)
+  allow_any_instance_of(ApplicationController).to receive(:current_user)
     .and_return(person)
   allow_any_instance_of(ApplicationController).to receive(:current_person)
     .and_return(person)


### PR DESCRIPTION
A user should not be able to roam around the site without first signing in. This PR introduces a sign in page, a application controller method to redirect on pages we want to keep hidden from un signed in users, implements that method across the needed controllers and has an slightly updated header.