### PR TITLE
Add nil check to policies

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -7,7 +7,7 @@ class ApplicationPolicy
   end
 
   def create?
-    person.admin?
+    person.present? && person.admin?
   end
 
   def new?
@@ -15,7 +15,7 @@ class ApplicationPolicy
   end
 
   def update?
-    person.admin?
+    person.present? && person.admin?
   end
 
   def edit?
@@ -23,6 +23,6 @@ class ApplicationPolicy
   end
 
   def destroy?
-    person.admin?
+    person.present? && person.admin?
   end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe ApplicationPolicy, type: :model do
     :edit?,
     :destroy?
   ]
+
+  context 'the person is not signed in' do
+    subject { ApplicationPolicy.new(nil_person, 'any object') }
+    let(:nil_person) { nil }
+
+    policy_methods.each do |method|
+      describe method.to_s do
+        it 'returns false' do
+          expect(subject.send(method)).to eq(false)
+        end
+      end
+    end
+  end
+
   context 'the person is an admin' do
     subject { ApplicationPolicy.new(admin, 'any object') }
     let(:admin) { FactoryGirl.build(:person, :admin) }


### PR DESCRIPTION
There are instances in which a user will not be
signed in whilst still navigiating our app. This nil
check is designed to avoid 500's when that environment is present

Pivotal: https://www.pivotaltracker.com/story/show/141909165