### PR TITLE
Feature/edit presentations

### DIFF
--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -12,6 +12,11 @@ class PresentationsController < ApplicationController
     authorize @presentation
   end
 
+  def edit
+    @presentation = Presentation.find(params[:id])
+    authorize @presentation
+  end
+
   def create
     if current_person && current_person.admin?
       @presentation = Presentation.new(admin_presentation_params)

--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -13,9 +13,13 @@ class PresentationsController < ApplicationController
   end
 
   def create
-    @presentation = Presentation.new(presentation_params).tap do |presentation|
-      presentation.person = current_person
+    if current_person && current_person.admin?
+      @presentation = Presentation.new(admin_presentation_params)
+    else
+      create_params = presentation_params.merge(person: current_person)
+      @presentation = Presentation.new(create_params)
     end
+
     authorize @presentation
 
     if @presentation.save
@@ -27,6 +31,17 @@ class PresentationsController < ApplicationController
   end
 
   private
+
+  def admin_presentation_params
+    params.require(:presentation).permit(
+      :presenter,
+      :topic,
+      :duration,
+      :description,
+      :event_id,
+      :person_id
+    )
+  end
 
   def presentation_params
     params.require(:presentation).permit(

--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -47,6 +47,14 @@ class PresentationsController < ApplicationController
     end
   end
 
+  def destroy
+    @presentation = Presentation.find(params[:id])
+    authorize @presentation
+    @presentation.destroy!
+
+    redirect_to presentations_path
+  end
+
   private
 
   def admin_presentation_params

--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -35,6 +35,18 @@ class PresentationsController < ApplicationController
     end
   end
 
+  def update
+    @presentation = Presentation.find(params[:id])
+    authorize @presentation
+
+    if @presentation.update(admin_presentation_params)
+      flash[:notice] = 'Presentation was successfully updated.'
+      redirect_to @presentation
+    else
+      render 'edit'
+    end
+  end
+
   private
 
   def admin_presentation_params

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -26,7 +26,9 @@ class Presentation < ApplicationRecord
   end
 
   def associated_event_has_available_time
-    return if event.nil? || event.duration + duration <= Event::MAXIMUM_DURATION
+    return if duration.nil? ||
+              event.nil? ||
+              event.duration + duration <= Event::MAXIMUM_DURATION
 
     errors.add(
       :event,

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,5 +1,3 @@
-<%= flash[:notice] %>
-
 <h1>Event: <%= @event.name %></h1>
 <dl>
   <dt>Name</dl>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
 
   <body>
     <%= render 'layouts/header' %>
+    <%= flash[:notice] %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/presentations/_form.html.erb
+++ b/app/views/presentations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @presentation do |f| %>
+<%= form_for presentation do |f| %>
   <%= render 'errors' %>
 
   <p>
@@ -20,6 +20,14 @@
     <%= f.label :event %><br>
     <%= f.collection_select(:event_id, Event.upcoming, :id, :name, prompt: true) %>
   </p>
+  <% if current_person && current_person.admin? %>
+    <p>
+      <%= f.label :presenter %><br>
+      <%= collection_select(:presentation, :person_id, Person.all, :id, :first_name, include_blank: true) %>
+      or
+      <%= f.text_field :presenter, placeholder: 'Enter guest name' %>
+    </p>
+  <% end %>
 
   <p>
     <%= f.submit %>

--- a/app/views/presentations/edit.html.erb
+++ b/app/views/presentations/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit Presentation</h1>
+
+<%= render 'form', presentation: @presentation %>

--- a/app/views/presentations/new.html.erb
+++ b/app/views/presentations/new.html.erb
@@ -1,3 +1,3 @@
 <h1>New Presentation</h1>
 
-<%= render 'form' %>
+<%= render 'form', presentation: @presentation  %>

--- a/app/views/presentations/show.html.erb
+++ b/app/views/presentations/show.html.erb
@@ -10,3 +10,9 @@
   <dt>Date</dt>
   <dd><%= @presentation.event.date %></dd>
 </dl>
+
+<%= link_to 'Edit', edit_presentation_path(@presentation) %>
+<%= link_to 'Delete', presentation_path(@presentation),
+  method: :delete,
+  data: { confirm: 'Are you sure?' } %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   resources :events do
     get 'upcoming', to: 'events#upcoming', on: :collection
   end
-  resources :presentations, except: [:edit, :update, :destroy]
+  resources :presentations
 
   root 'welcome#index'
 end

--- a/spec/controllers/presentations_controller_spec.rb
+++ b/spec/controllers/presentations_controller_spec.rb
@@ -1,28 +1,122 @@
 require 'rails_helper'
 
 RSpec.describe PresentationsController, type: :controller do
-  context 'the current person is an admin' do
-    let(:admin_person) { FactoryGirl.build(:person, :admin) }
+  let(:nil_person) { nil }
+  let(:non_admin) { FactoryGirl.build(:person) }
+  let(:admin_person) { FactoryGirl.build(:person, :admin) }
 
-    before { mock_pundit_user_as(admin_person) }
+  describe 'GET #index' do
+    subject { get :index }
 
-    describe 'GET #new' do
-      subject { get :new }
+    context 'the current person is not signed in' do
+      before { mock_pundit_user_as(nil_person) }
+
+      it { is_expected.to render_template :index }
+      it { is_expected.to be_successful }
+    end
+  end
+
+  describe 'GET #show' do
+    subject { get :show, params: { id: presentation.id } }
+    let!(:presentation) { FactoryGirl.create(:presentation) }
+
+    context 'the current person is not signed in' do
+      before { mock_pundit_user_as(nil_person) }
+
+      it { is_expected.to render_template :show }
+      it { is_expected.to be_successful }
+    end
+  end
+
+  describe 'GET #new' do
+    subject { get :new }
+
+    context 'the current person is not signed in' do
+      before { mock_pundit_user_as(nil_person) }
+
+      it 'throws a not authorized error' do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'the current person is a non-admin' do
+      before { mock_pundit_user_as(non_admin) }
 
       it { is_expected.to render_template :new }
       it { is_expected.to be_successful }
     end
+  end
 
-    describe 'POST #create' do
-      subject { post :create, params: { presentation: params } }
-      let!(:person) { FactoryGirl.create(:person) }
-      let!(:event) { FactoryGirl.create(:event) }
+  describe 'GET #edit' do
+    subject { get :edit, params: { id: presentation.id } }
+    let(:presentation) { FactoryGirl.create(:presentation) }
+
+    context 'the current person is a non-admin' do
+      before { mock_pundit_user_as(non_admin) }
+
+      it 'throws a not authorized error' do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'the current person is an admin' do
+      before { mock_pundit_user_as(admin_person) }
+
+      it { is_expected.to render_template :edit }
+      it { is_expected.to be_successful }
+    end
+  end
+
+  describe 'POST #create' do
+    subject { post :create, params: { presentation: params } }
+    let(:event) { FactoryGirl.create(:event) }
+    let(:person) { FactoryGirl.create(:person) }
+
+    context 'the current person is not signed in' do
+      before { mock_pundit_user_as(nil_person) }
+
+      let(:params) do
+        FactoryGirl.attributes_for(
+          :presentation,
+          event_id: event.id
+        )
+      end
+
+      it 'throws a not authorized error' do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'the current person is a non-admin' do
+      before { mock_pundit_user_as(non_admin) }
+
+      let(:params) do
+        FactoryGirl.attributes_for(
+          :presentation,
+          event_id: event.id
+        )
+      end
+
+      it { is_expected.to redirect_to Presentation.last }
+
+      it 'is expected to be successful' do
+        expect(response).to be_success
+      end
+
+      it 'is expected to change presentation count +1' do
+        expect { subject }.to change(Presentation, :count).by(1)
+      end
+    end
+
+    context 'the current person is an admin' do
+      before { mock_pundit_user_as(admin_person) }
 
       context 'valid params' do
         let(:params) do
           FactoryGirl.attributes_for(
             :presentation,
-            event_id: event.id
+            event_id: event.id,
+            person_id: person.id
           )
         end
 
@@ -49,45 +143,72 @@ RSpec.describe PresentationsController, type: :controller do
       end
     end
   end
-  context 'the current person is a non-admin' do
-    let(:non_admin) { FactoryGirl.build(:person) }
 
-    before { mock_pundit_user_as(non_admin) }
-
-    describe 'GET #show' do
-      subject { get :show, params: { id: presentation.id } }
-      let!(:presentation) { FactoryGirl.create(:presentation) }
-
-      it { is_expected.to render_template :show }
-      it { is_expected.to be_successful }
+  describe 'PATCH #update' do
+    subject do
+      patch :update, params: { id: presentation.id, presentation: attr }
     end
-  end
+    let(:presentation) { FactoryGirl.create(:presentation) }
 
-  context 'the current person is not signed in' do
-    let(:nil_person) { nil }
+    context 'the current person is a non-admin' do
+      before { mock_pundit_user_as(non_admin) }
+      let(:attr) { { topic: 'New Topic' } }
 
-    before { mock_pundit_user_as(nil_person) }
-
-    describe 'POST #create' do
-      subject { post :create, params: { presentation: params } }
-      let(:event) { FactoryGirl.create(:event) }
-      let(:params) do
-        FactoryGirl.attributes_for(
-          :presentation,
-          event_id: event.id
-        )
-
-        it 'throws a not authorized error' do
-          expect { subject }.to raise_error(Pundit::NotAuthorizedError)
-        end
+      it 'throws a not authorized error' do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
-    describe 'GET #index' do
-      subject { get :index }
+    context 'the current person is an admin' do
+      before { mock_pundit_user_as(admin_person) }
 
-      it { is_expected.to render_template :index }
-      it { is_expected.to be_successful }
+      context 'changing topic' do
+        let(:attr) { { topic: 'New Topic' } }
+
+        it { is_expected.to redirect_to presentation }
+
+        it 'should update presentation' do
+          expect { subject }
+            .to change { presentation.reload.topic }
+            .from('Being Awesome')
+            .to('New Topic')
+        end
+      end
+
+      context 'invalid attributes' do
+        let(:attr) { { topic: nil } }
+
+        it { is_expected.to render_template :edit }
+
+        it 'should not update presentation' do
+          expect { subject }
+            .to_not change { presentation.reload.topic }
+            .from('Being Awesome')
+        end
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    subject { delete :destroy, params: { id: presentation.id } }
+    let!(:presentation) { FactoryGirl.create(:presentation) }
+
+    context 'the current person is a non-admin' do
+      before { mock_pundit_user_as(non_admin) }
+
+      it 'throws a not authorized error' do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'the current person is an admin' do
+      before { mock_pundit_user_as(admin_person) }
+
+      it { is_expected.to redirect_to presentations_path }
+
+      it 'changes presentation count by -1' do
+        expect { subject }.to change(Presentation, :count).by(-1)
+      end
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/140277883

This PR updates presentation controller and associated views to allow an admin to edit/update, or delete a presentation.

This PR is dependent on https://github.com/StemboltHQ/staff_tracker/tree/feature/sign-in-mandatory as an admin user needs to be logged in to have update/destroy authorization.