### PR TITLE
Feature/edit events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,6 +13,11 @@ class EventsController < ApplicationController
     @events = Event.upcoming
   end
 
+  def edit
+    @event = Event.find(params[:id])
+    authorize @event
+  end
+
   def create
     @event = Event.new(event_params)
     authorize @event

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -30,6 +30,18 @@ class EventsController < ApplicationController
     end
   end
 
+  def update
+    @event = Event.find(params[:id])
+    authorize @event
+
+    if @event.update(event_params)
+      flash[:notice] = 'Event was successfully updated.'
+      redirect_to @event
+    else
+      render 'edit'
+    end
+  end
+
   private
 
   def event_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -46,6 +46,14 @@ class EventsController < ApplicationController
     end
   end
 
+  def destroy
+    @event = Event.find(params[:id])
+    authorize @event
+    @event.destroy!
+
+    redirect_to events_path
+  end
+
   private
 
   def event_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,9 @@
 # app/controllers/events_controller.rb
 class EventsController < ApplicationController
+  def index
+    @events = Event.all
+  end
+
   def show
     @event = Event.find(params[:id])
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,7 +2,7 @@
 class Event < ApplicationRecord
   NOTIFICATION_PERIOD = 1.day
   MAXIMUM_DURATION = Figaro.env.maximum_event_duration.to_i
-  has_many :presentations
+  has_many :presentations, dependent: :destroy
 
   validates :date,
             presence: true

--- a/app/views/events/_delete-link.html.erb
+++ b/app/views/events/_delete-link.html.erb
@@ -1,0 +1,10 @@
+<%=
+  link_to 'Delete', event_path(event),
+  method: :delete,
+  data:
+    if event.presentations.any?
+      { confirm: 'Are you sure? Deleting this event will delete all associated presentations.' }
+    else
+      { confirm: 'Are you sure?' }
+    end
+%>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -3,5 +3,6 @@
   <td>
     <%= link_to 'Show', event_path(event) %>
     <%= link_to 'Edit', edit_event_path(event) %>
+    <%= render partial: 'delete-link', locals: { event: event } %>
   </td>
 </tr>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,0 +1,7 @@
+<tr>
+  <td><%= event.name %></td>
+  <td>
+    <%= link_to 'Show', event_path(event) %>
+    <%= link_to 'Edit', edit_event_path(event) %>
+  </td>
+</tr>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit Event</h1>
+
+<%= render 'form' %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,15 @@
+<h1>Events</h1>
+
+<%= link_to 'New Event', new_event_path %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render @events %>
+  </tbody>
+</table>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,3 +1,5 @@
+<%= flash[:notice] %>
+
 <h1>Event: <%= @event.name %></h1>
 <dl>
   <dt>Name</dl>
@@ -9,3 +11,6 @@
   <dt>Location</dt>
   <dd><%= @event.location %></dd>
 </dl>
+
+<%= link_to 'Edit', edit_event_path(@event) %>
+<%= render partial: 'delete-link', locals: { event: @event } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   resources :sessions, only: [:destroy]
   resources :people
-  resources :events, only: [:show, :create, :new] do
+  resources :events do
     get 'upcoming', to: 'events#upcoming', on: :collection
   end
   resources :presentations, only: [:show, :create, :new]

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -125,6 +125,13 @@ RSpec.describe EventsController, type: :controller do
       end
     end
 
+    describe 'GET #index' do
+      subject { get :index }
+
+      it { is_expected.to render_template(:index) }
+      it { is_expected.to be_successful }
+    end
+
     describe 'GET #upcoming' do
       subject { get :upcoming }
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe EventsController, type: :controller do
 
     before { mock_pundit_user_as(admin_person) }
 
+    describe 'GET #edit' do
+      let(:event) { FactoryGirl.create(:event) }
+      subject { get :edit, params: { id: event.id } }
+
+      it { is_expected.to render_template :edit }
+      it { is_expected.to be_successful }
+    end
+
     describe 'POST #create' do
       subject { post :create, params: { event: params } }
 
@@ -62,6 +70,15 @@ RSpec.describe EventsController, type: :controller do
 
     describe 'GET #new' do
       subject { get :new }
+
+      it 'throws a not authorized error' do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    describe 'GET #edit' do
+      let(:event) { FactoryGirl.create(:event) }
+      subject { get :edit, params: { id: event.id } }
 
       it 'throws a not authorized error' do
         expect { subject }.to raise_error(Pundit::NotAuthorizedError)

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -46,6 +46,36 @@ RSpec.describe EventsController, type: :controller do
       end
     end
 
+    describe 'PATCH #update' do
+      let(:event) { FactoryGirl.create(:event) }
+      subject { patch :update, params: { id: event.id, event: attr } }
+
+      context 'changing name ' do
+        let(:attr) { { name: 'New Name' } }
+
+        it { is_expected.to redirect_to event }
+
+        it 'should update event' do
+          expect { subject }
+            .to change { event.reload.name }
+            .from('Show & Tell')
+            .to('New Name')
+        end
+      end
+
+      context 'invalid attributes' do
+        let(:attr) { { name: nil } }
+
+        it { is_expected.to render_template :edit }
+
+        it 'shouldn\'t update event' do
+          expect { subject }
+            .to_not change { event.reload.name }
+            .from('Show & Tell')
+        end
+      end
+    end
+
     describe 'GET #new' do
       subject { get :new }
 
@@ -62,6 +92,16 @@ RSpec.describe EventsController, type: :controller do
     describe 'POST #create' do
       subject { post :create, params: { event: params } }
       let(:params) { FactoryGirl.attributes_for(:event) }
+
+      it 'throws a not authorized error' do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    describe 'PATCH #update' do
+      subject { patch :update, params: { id: event.id, event: attr } }
+      let(:event) { FactoryGirl.create(:event) }
+      let(:attr) { { name: 'New Name' } }
 
       it 'throws a not authorized error' do
         expect { subject }.to raise_error(Pundit::NotAuthorizedError)

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -76,6 +76,17 @@ RSpec.describe EventsController, type: :controller do
       end
     end
 
+    describe 'DELETE #destroy' do
+      let!(:event) { FactoryGirl.create(:event) }
+      subject { delete :destroy, params: { id: event.id } }
+
+      it { is_expected.to redirect_to events_path }
+
+      it 'changes event count by -1' do
+        expect { subject }.to change(Event, :count).by(-1)
+      end
+    end
+
     describe 'GET #new' do
       subject { get :new }
 
@@ -102,6 +113,15 @@ RSpec.describe EventsController, type: :controller do
       subject { patch :update, params: { id: event.id, event: attr } }
       let(:event) { FactoryGirl.create(:event) }
       let(:attr) { { name: 'New Name' } }
+
+      it 'throws a not authorized error' do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      let(:event) { FactoryGirl.create(:event) }
+      subject { delete :destroy, params: { id: event.id } }
 
       it 'throws a not authorized error' do
         expect { subject }.to raise_error(Pundit::NotAuthorizedError)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,6 +2,16 @@
 require 'rails_helper'
 
 RSpec.describe Event, type: :model do
+  describe 'Event associations' do
+    subject { described_class.reflect_on_association(:presentations) }
+    it 'has many presentations' do
+      expect(subject.macro).to eq :has_many
+    end
+    it 'destroys dependents' do
+      expect(subject.options[:dependent]) .to eq(:destroy)
+    end
+  end
+
   subject { described_class.new(event) }
 
   describe 'valid model' do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/140278149

This PR updates events controller and associated views to allow an admin to edit/update, or delete an event.

Upon event deletion, any associated presentations are also deleted. A conditional confirmation message for event deletion warns user that presentations for this event will also be deleted.

For views/actions currently limited to admin, a 500 error is displayed if the user is not a logged in admin. 