### PR TITLE
Bug/homepage presenter name

### DIFF
--- a/app/views/welcome/_next-event.html.erb
+++ b/app/views/welcome/_next-event.html.erb
@@ -10,7 +10,7 @@
 
       <ul>
         <% next_event.presentations.each do |presentation| %>
-          <li><%= "#{presentation.presenter} \u2013 #{presentation.topic}
+          <li><%= "#{presentation.presenter_name} \u2013 #{presentation.topic}
           (#{presentation.duration} min)" %></li>
         <% end %>
       </ul>


### PR DESCRIPTION
Homepage was only rendering presenter name for guest presenters. Now presenter name is correctly rendered for either guest presenters or for staff tracker users giving presentations.