### PR TITLE
Update presentation policy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Metrics/BlockLength:
 Metrics/LineLength:
   IgnoredPatterns:
     - '\w*it.+do'
+    - '\w*context.+do'
 
 Style/Lambda:
     Enabled: false

--- a/app/policies/presentation_policy.rb
+++ b/app/policies/presentation_policy.rb
@@ -6,4 +6,12 @@ class PresentationPolicy < ApplicationPolicy
   def new?
     create?
   end
+
+  def update?
+    (person&.admin? || person&.presentations&.include?(record)).present?
+  end
+
+  def edit?
+    update?
+  end
 end

--- a/spec/policies/presentation_policy_spec.rb
+++ b/spec/policies/presentation_policy_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe PresentationPolicy, type: :model do
-  policy_methods = [
+  requiring_sign_in_methods = [
     :create?,
-    :new?
+    :new?,
+    :update?,
+    :edit?
   ]
 
   describe PresentationPolicy do
@@ -15,23 +17,69 @@ RSpec.describe PresentationPolicy, type: :model do
       subject { PresentationPolicy.new(nil_person, 'any_object') }
       let(:nil_person) { nil }
 
-      policy_methods.each do |method|
+      requiring_sign_in_methods.each do |method|
         describe method.to_s do
           it 'returns false' do
-            expect(subject.send(method)).to eq(false)
+            expect(subject.send(method)).to be(false)
           end
         end
       end
     end
 
-    context 'the person is a non admin' do
-      subject { PresentationPolicy.new(non_admin, 'any_object') }
-      let(:non_admin) { FactoryGirl.build(:person) }
+    context 'the person is an admin' do
+      subject { described_class.new(admin, presentation) }
+      let(:admin) { FactoryGirl.build(:person, :admin) }
+      let(:presentation) { FactoryGirl.build(:presentation) }
 
-      policy_methods.each do |method|
-        describe method.to_s do
+      describe '.update?' do
+        it 'returns true' do
+          expect(subject.update?).to be(true)
+        end
+      end
+
+      describe '.edit?' do
+        it 'calls the .update? method' do
+          expect(subject).to receive(:update?)
+          subject.edit?
+        end
+      end
+    end
+
+    context 'the person is a non admin' do
+      subject { PresentationPolicy.new(non_admin, presentation) }
+      let(:non_admin) { FactoryGirl.build(:person) }
+      let(:presentation) { FactoryGirl.build(:presentation) }
+
+      describe '.update?' do
+        context 'the presentation being taken action on belongs to the person' do
+          before do
+            non_admin.presentations << presentation
+          end
+
           it 'returns true' do
-            expect(subject.send(method)).to eq(true)
+            expect(subject.update?).to eq(true)
+          end
+        end
+        context 'the presentation being taken action on doesnt belong to the person' do
+          it 'returns false' do
+            expect(subject.update?).to eq(false)
+          end
+        end
+      end
+
+      describe '.edit?' do
+        context 'the presentation being taken action on belongs to the person' do
+          before do
+            non_admin.presentations << presentation
+          end
+
+          it 'returns true' do
+            expect(subject.update?).to eq(true)
+          end
+        end
+        context 'the presentation being taken action on doesnt belong to the person' do
+          it 'returns false' do
+            expect(subject.update?).to eq(false)
           end
         end
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/140356259

Ruby target version was changed because Brendan has asked for us to use the safe navigation operator introduced in ruby 2.3

People should be able to edit their own presentations
so they can fix typos etc.