### PR TITLE
Update target ruby version in rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.3
   Exclude:
     - 'db/**/*'
     - 'config/**/*'

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,7 +5,7 @@ class Person < ApplicationRecord
 
   before_save do
     email.downcase!
-    gender.downcase! if gender
+    gender&.downcase!
   end
 
   valid_email_regex = /.+@.+\..+/i


### PR DESCRIPTION
Jenkins build was recently updated to use Ruby 2.3.1. This PR updates the ruby version being parsed by rubocop.

In order for this PR to pass Jenkins, the person model file needed to be updated to use safe navigation, otherwise rubocop flags an offense.