### PR TITLE
Create custom 403 error page for Pundit errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,5 @@
+class ErrorsController < ApplicationController
+  def forbidden
+    render status: 403
+  end
+end

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,7 @@
+<div class='main'>
+  <h1>Woops!</h1>
+  <p>You do not have access to this page.</p>
+  <% if !current_person %>
+    <p>  This is most likely being caused because you are not <%= link_to 'signed in', '/auth/google_oauth2' %>.</p>
+  <% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,11 @@ module StaffTracker
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.action_dispatch
+          .rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
+
+    require Rails.root.join('lib/custom_public_exceptions')
+    config.exceptions_app = CustomPublicExceptions.new(Rails.public_path)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get 'auth/failure', to: redirect('/')
   get 'signout', to: 'sessions#destroy', as: 'signout'
   get 'authentication/google', to: 'authentication#google'
+  match '/403', to: 'errors#forbidden', via: :all
 
   resources :sessions, only: [:destroy]
   resources :people

--- a/lib/custom_public_exceptions.rb
+++ b/lib/custom_public_exceptions.rb
@@ -1,0 +1,10 @@
+class CustomPublicExceptions < ActionDispatch::PublicExceptions
+  def call(env)
+    status = env["PATH_INFO"][1..-1]
+    if status == '403'
+      Rails.application.routes.call(env)
+    else
+      super
+    end
+  end
+end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe ErrorsController, type: :controller do
+  describe 'GET #forbidden' do
+    subject { get :forbidden }
+    it { is_expected.to render_template :forbidden }
+    it { is_expected.to have_http_status(403) }
+  end
+end

--- a/spec/lib/custom_public_exceptions_spec.rb
+++ b/spec/lib/custom_public_exceptions_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe CustomPublicExceptions do
+  describe '#call' do
+    subject { described_class.new(Rails.public_path).call(env) }
+
+    context 'the status is 403' do
+      let(:env) { Rack::MockRequest.env_for('/403') }
+      it { is_expected.to be_instance_of(Array) }
+      it { is_expected.to start_with 403 }
+    end
+
+    context 'the status is not 403' do
+      let(:env) { Rack::MockRequest.env_for('/500') }
+      it { is_expected.to be_instance_of(Array) }
+      it { is_expected.to start_with 500 }
+    end
+  end
+end


### PR DESCRIPTION
Rescue pundit errors and redirect to /403 route.

https://www.pivotaltracker.com/story/show/142092195