### PR TITLE
Bug/person last name

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -17,7 +17,7 @@ class AuthenticationController < ApplicationController
     random_password = SecureRandom.hex(10)
     {
       first_name: auth.extra.raw_info.given_name,
-      last_name: auth.extra.raw_info.last_name,
+      last_name: auth.extra.raw_info.family_name,
       email: auth.extra.raw_info.email,
       provider: auth.provider,
       uid: auth.uid,


### PR DESCRIPTION
While working through an unrelated story, I noticed that the database was not populating Person.last_name from Google Oauth. The reason is that the Authentication controller was using "last_name" and the google api uses "family_name". This PR replaces last_name with family_name IOT correct this issue.