### PR TITLE
Update authentication controller redirect

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -8,7 +8,7 @@ class AuthenticationController < ApplicationController
       new_person.attributes = google_params(auth)
     end
     session[:person_id] = person.id
-    redirect_to root_path
+    redirect_to request.env['omniauth.origin'] || root_path
   end
 
   private

--- a/spec/controllers/authentication_controller_spec.rb
+++ b/spec/controllers/authentication_controller_spec.rb
@@ -10,14 +10,33 @@ RSpec.describe AuthenticationController, type: :controller do
       post :google
       response
     end
+
     it 'creates a new person' do
       expect { subject }.to change { Person.count }.by(1)
     end
-    it 'redirects the person to the root url' do
-      expect(subject).to redirect_to(root_url)
-    end
+
     it 'creates a new session' do
       expect { subject }.to change { session[:person_id] }.from nil
+    end
+
+    context 'omniauth origin is nil' do
+      before do
+        request.env['omniauth.origin'] = nil
+      end
+
+      it 'redirects the person to the root url' do
+        expect(subject).to redirect_to(root_url)
+      end
+    end
+
+    context 'omniauth origin is not nil' do
+      before do
+        request.env['omniauth.origin'] = 'http://test.host/presentations'
+      end
+
+      it 'redirects the person to the path location saved prior to login' do
+        expect(subject).to redirect_to(presentations_path)
+      end
     end
   end
 end


### PR DESCRIPTION
Pivotal Story: https://www.pivotaltracker.com/story/show/142616283

Adding ```redirect_to request.env['omniauth.origin']``` will redirect user to back to the page they were on prior to signing in.

https://github.com/omniauth/omniauth/wiki/saving-user-location